### PR TITLE
Fix tool installation command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ All these commands are powered with [.NET regular expression engine](https://doc
 Orang is distributed as a [.NET Core global tool](https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools). To install Orang run:
 
 ```
-dotnet install tool -g orang.dotnet.cli
+dotnet tool install -g orang.dotnet.cli
 ```
 
 To install non-alpha version run:
 
 ```
-dotnet install tool -g orang.dotnet.cli --version 0.1.0-beta
+dotnet tool install -g orang.dotnet.cli --version 0.1.0-beta
 ```
 
 To update Orang run:


### PR DESCRIPTION
Using the current instruction (e.g. `dotnet install tool -g orang.dotnet.cli --version 0.1.0-beta`), one gets the error message:

```
Could not execute because the specified command or file was not found.
Possible reasons for this include:
  * You misspelled a built-in dotnet command.
  * You intended to execute a .NET Core program, but dotnet-install does not exist.
  * You intended to run a global tool, but a dotnet-prefixed executable with this name could not be found on the PATH.
```

This PR fixes the instructions, where `install` should appear _after_ `tool` as it is a sub-command of `tool`.